### PR TITLE
Drop string metrics

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/rollup/StringMetricsPersistenceOptimizerIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/rollup/StringMetricsPersistenceOptimizerIntegrationTest.java
@@ -133,7 +133,6 @@ public class StringMetricsPersistenceOptimizerIntegrationTest extends
 
     @Test
     public void testShouldPersistIfConfigValueFalse() throws Exception {
-        System.setProperty(CoreConfig.STRING_METRICS_DROPPED.name(), "false");
         final Locator dummyLocator = Locator.createLocatorFromDbKey("acct.ent.check.dim.metric");
         final long collectionTimeInSecs = 45678;
         final String testMetric = "HTTP GET failed";
@@ -153,9 +152,9 @@ public class StringMetricsPersistenceOptimizerIntegrationTest extends
         final long collectionTimeInSecs = 45678;
         final String testMetric = "HTTP GET failed";
         final Metric newMetric = new Metric(dummyLocator, testMetric, collectionTimeInSecs,
-                new TimeValue(2, TimeUnit.DAYS), "unknown");
 
-        System.setProperty(CoreConfig.STRING_METRICS_DROPPED.name(), "true");
+        new TimeValue(2, TimeUnit.DAYS), "unknown");
+        StringMetricsPersistenceOptimizer.stringMetricsAreDropped();
         boolean shouldPersist = metricsOptimizer.shouldPersist(newMetric);
 
         // shouldPersist should return true as cassandra doesn't have any
@@ -165,6 +164,6 @@ public class StringMetricsPersistenceOptimizerIntegrationTest extends
 
     @After
     public void tearDown() throws Exception {
-        System.setProperty(CoreConfig.STRING_METRICS_DROPPED.name(),String.valueOf(areStringMetricsDropped));
+        StringMetricsPersistenceOptimizer.stringMetricsDroppedIsReset();
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/rollup/StringMetricsPersistenceOptimizer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/rollup/StringMetricsPersistenceOptimizer.java
@@ -17,6 +17,8 @@
 package com.rackspacecloud.blueflood.rollup;
 
 import com.rackspacecloud.blueflood.io.AstyanaxReader;
+import com.rackspacecloud.blueflood.service.Configuration;
+import com.rackspacecloud.blueflood.service.CoreConfig;
 import com.rackspacecloud.blueflood.types.Metric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,9 +38,15 @@ public class StringMetricsPersistenceOptimizer implements
 
     @Override
     public boolean shouldPersist(Metric metric) throws Exception {
-        String currentValue = String.valueOf(metric.getMetricValue());
-        final String lastValue = AstyanaxReader.getInstance().getLastStringValue(metric.getLocator());
-
-        return lastValue == null || !currentValue.equals(lastValue);
+        boolean areStringMetricsDropped = Configuration.getInstance().getBooleanProperty(CoreConfig.STRING_METRICS_DROPPED);
+        
+        if(areStringMetricsDropped) {
+           return false;
+        }
+        else {
+            String currentValue = String.valueOf(metric.getMetricValue());
+            final String lastValue = AstyanaxReader.getInstance().getLastStringValue(metric.getLocator());
+            return lastValue == null || !currentValue.equals(lastValue);
+        }
     }
 }

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/rollup/StringMetricsPersistenceOptimizer.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/rollup/StringMetricsPersistenceOptimizer.java
@@ -31,16 +31,25 @@ public class StringMetricsPersistenceOptimizer implements
         MetricsPersistenceOptimizer {
     private static final Logger log = LoggerFactory.getLogger(
             StringMetricsPersistenceOptimizer.class);
+    private static boolean areStringMetricsDropped = Configuration.getInstance().getBooleanProperty(CoreConfig.STRING_METRICS_DROPPED);
 
     public StringMetricsPersistenceOptimizer() {
         // left empty
     }
 
+    //to be called from tests
+    public static void stringMetricsAreDropped() {
+        areStringMetricsDropped = true;
+    }
+
+    //to be invoked only from tests
+    public static void stringMetricsDroppedIsReset() {
+        areStringMetricsDropped = Configuration.getInstance().getBooleanProperty(CoreConfig.STRING_METRICS_DROPPED);
+    }
+
     @Override
     public boolean shouldPersist(Metric metric) throws Exception {
-        boolean areStringMetricsDropped = Configuration.getInstance().getBooleanProperty(CoreConfig.STRING_METRICS_DROPPED);
-        
-        if(areStringMetricsDropped) {
+        if (areStringMetricsDropped) {
            return false;
         }
         else {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -132,7 +132,8 @@ public enum CoreConfig implements ConfigDefaults {
     METADATA_CACHE_PERSISTENCE_ENABLED("false"),
     METADATA_CACHE_PERSISTENCE_PATH("/dev/null"),
     METADATA_CACHE_PERSISTENCE_PERIOD_MINS("10"),
-    META_CACHE_RETENTION_IN_MINUTES("10");
+    META_CACHE_RETENTION_IN_MINUTES("10"),
+    STRING_METRICS_DROPPED("false");
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());


### PR DESCRIPTION
Drop String Metrics if so configured.
Also, added support to keep string metrics for certain tenants
