### PR TITLE
Drop string metrics

### DIFF
--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/MetricsIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/MetricsIntegrationTest.java
@@ -317,8 +317,7 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
         HashSet<String> keptTenants = new HashSet<String>();
         keptTenants.add(locator.getTenantId());
 
-        //AstyanaxWriter.setTenantIdsKept(keptTenants);
-        Whitebox.setInternalState(AstyanaxWriter.getInstance(), "keptTenantIds",keptTenants);
+        Whitebox.setInternalState(AstyanaxWriter.getInstance(), "keptTenantIdsSet",keptTenants);
 
         Set<Long> expectedTimestamps = new HashSet<Long>();
         // insert something every 30s for 5 mins.

--- a/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/MetricsIntegrationTest.java
+++ b/blueflood-core/src/integration-test/java/com/rackspacecloud/blueflood/service/MetricsIntegrationTest.java
@@ -268,6 +268,7 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    //In this test, string metrics are configured to be always dropped. So they are not persisted at all.
     public void testStringMetricsIfSoConfiguredAreAlwaysDropped() throws Exception {
         System.setProperty(CoreConfig.STRING_METRICS_DROPPED.name(),"true");
         Configuration.getInstance().init();
@@ -302,6 +303,7 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    //In this test, string metrics are not configured to be dropped so they are persisted.
     public void testStringMetricsIfSoConfiguredArePersistedAsExpected() throws Exception {
         System.setProperty(CoreConfig.STRING_METRICS_DROPPED.name(),"false");
         Configuration.getInstance().init();
@@ -336,6 +338,7 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    //In this test, we attempt to persist the same value of String Metric every single time. Only the first one is persisted.
     public void testStringMetricsWithSameValueAreNotPersisted() throws Exception {
         AstyanaxWriter writer = AstyanaxWriter.getInstance();
         AstyanaxReader reader = AstyanaxReader.getInstance();
@@ -348,6 +351,7 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
         String sameValue = getRandomStringMetricValue();
         Set<Long> expectedTimestamps = new HashSet<Long>();
         // insert something every 30s for 5 mins.
+        //value remains the same
         for (int i = 0; i < 10; i++) {
             final long curMillis = baseMillis + (i * 30000); // 30 seconds later.
 
@@ -371,6 +375,8 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    //In this case, we alternate between two values for a string metric. But since the string metric does not have the same value in two
+    //consecutive writes, it's always persisted.
     public void testStringMetricsWithDifferentValuesArePersisted() throws Exception {
         AstyanaxWriter writer = AstyanaxWriter.getInstance();
         AstyanaxReader reader = AstyanaxReader.getInstance();
@@ -385,6 +391,7 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
 
         Set<Long> expectedTimestamps = new HashSet<Long>();
         // insert something every 30s for 5 mins.
+        //string metric value is alternated.
         for (int i = 0; i < 10; i++) {
             final long curMillis = baseMillis + (i * 30000); // 30 seconds later.
             String value = null;
@@ -409,6 +416,7 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    //Numeric value is always persisted.
     public void testNumericMetricsAreAlwaysPersisted() throws Exception {
         AstyanaxWriter writer = AstyanaxWriter.getInstance();
         AstyanaxReader reader = AstyanaxReader.getInstance();
@@ -421,6 +429,7 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
         int sameValue = getRandomIntMetricValue();
         Set<Long> expectedTimestamps = new HashSet<Long>();
         // insert something every 30s for 5 mins.
+        //value of numeric metric remains the same, still it is always persisted
         for (int i = 0; i < 10; i++) {
             final long curMillis = baseMillis + (i * 30000); // 30 seconds later.
             expectedTimestamps.add(curMillis);
@@ -439,6 +448,7 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    //In this test, the same value is sent, and the metric is not persisted except for the first time.
     public void testBooleanMetricsWithSameValueAreNotPersisted() throws Exception {
         AstyanaxWriter writer = AstyanaxWriter.getInstance();
         AstyanaxReader reader = AstyanaxReader.getInstance();
@@ -473,6 +483,7 @@ public class MetricsIntegrationTest extends IntegrationTestBase {
     }
 
     @Test
+    //In this test, we alternately persist true and false. All the boolean metrics are persisted.
     public void testBooleanMetricsWithDifferentValuesArePersisted() throws Exception {
         AstyanaxWriter writer = AstyanaxWriter.getInstance();
         AstyanaxReader reader = AstyanaxReader.getInstance();

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
@@ -40,9 +40,7 @@ import com.rackspacecloud.blueflood.utils.Util;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 
 public class AstyanaxWriter extends AstyanaxIO {
@@ -71,8 +69,11 @@ public class AstyanaxWriter extends AstyanaxIO {
 
     private boolean shouldPersistStringMetric(Metric metric) {
         final boolean areStringMetricsDropped = Configuration.getInstance().getBooleanProperty(CoreConfig.STRING_METRICS_DROPPED);
+        final String tenantIdsKept = Configuration.getInstance().getStringProperty(CoreConfig.TENANTIDS_TO_KEEP);
+        Set<String> keptTenantIds = new HashSet<String>(Arrays.asList(tenantIdsKept.split(",")));
+        String tenantId = metric.getLocator().getTenantId();
 
-        if(areStringMetricsDropped) {
+        if(areStringMetricsDropped && !keptTenantIds.contains(tenantId) ) {
             return false;
         }
         else {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
@@ -53,8 +53,8 @@ public class AstyanaxWriter extends AstyanaxIO {
 
     private static final String INSERT_ROLLUP_BATCH = "Rollup Batch Insert".intern();
     private boolean areStringMetricsDropped = Configuration.getInstance().getBooleanProperty(CoreConfig.STRING_METRICS_DROPPED);
-    private String tenantIdsKept = Configuration.getInstance().getStringProperty(CoreConfig.TENANTIDS_TO_KEEP);
-    private Set<String> keptTenantIds = new HashSet<String>(Arrays.asList(tenantIdsKept.split(",")));
+    private List<String> tenantIdsKept = Configuration.getInstance().getListProperty(CoreConfig.TENANTIDS_TO_KEEP);
+    private Set<String> keptTenantIdsSet = new HashSet<String>(tenantIdsKept);
 
     public static AstyanaxWriter getInstance() {
         return instance;
@@ -72,7 +72,7 @@ public class AstyanaxWriter extends AstyanaxIO {
     private boolean shouldPersistStringMetric(Metric metric) {
         String tenantId = metric.getLocator().getTenantId();
 
-        if(areStringMetricsDropped && !keptTenantIds.contains(tenantId) ) {
+        if(areStringMetricsDropped && !keptTenantIdsSet.contains(tenantId) ) {
             return false;
         }
         else {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
@@ -52,6 +52,9 @@ public class AstyanaxWriter extends AstyanaxIO {
     private static final int LOCATOR_TTL = 604800;  // in seconds (7 days)
 
     private static final String INSERT_ROLLUP_BATCH = "Rollup Batch Insert".intern();
+    private boolean areStringMetricsDropped = Configuration.getInstance().getBooleanProperty(CoreConfig.STRING_METRICS_DROPPED);
+    private String tenantIdsKept = Configuration.getInstance().getStringProperty(CoreConfig.TENANTIDS_TO_KEEP);
+    private Set<String> keptTenantIds = new HashSet<String>(Arrays.asList(tenantIdsKept.split(",")));
 
     public static AstyanaxWriter getInstance() {
         return instance;
@@ -66,11 +69,7 @@ public class AstyanaxWriter extends AstyanaxIO {
     private static final Cache<String, Boolean> insertedLocators = CacheBuilder.newBuilder().expireAfterAccess(10,
             TimeUnit.MINUTES).concurrencyLevel(16).build();
 
-
     private boolean shouldPersistStringMetric(Metric metric) {
-        final boolean areStringMetricsDropped = Configuration.getInstance().getBooleanProperty(CoreConfig.STRING_METRICS_DROPPED);
-        final String tenantIdsKept = Configuration.getInstance().getStringProperty(CoreConfig.TENANTIDS_TO_KEEP);
-        Set<String> keptTenantIds = new HashSet<String>(Arrays.asList(tenantIdsKept.split(",")));
         String tenantId = metric.getLocator().getTenantId();
 
         if(areStringMetricsDropped && !keptTenantIds.contains(tenantId) ) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/io/AstyanaxWriter.java
@@ -33,9 +33,7 @@ import com.rackspacecloud.blueflood.cache.TenantTtlProvider;
 import com.rackspacecloud.blueflood.io.serializers.NumericSerializer;
 import com.rackspacecloud.blueflood.io.serializers.StringMetadataSerializer;
 import com.rackspacecloud.blueflood.rollup.Granularity;
-import com.rackspacecloud.blueflood.service.SingleRollupWriteContext;
-import com.rackspacecloud.blueflood.service.SlotState;
-import com.rackspacecloud.blueflood.service.UpdateStamp;
+import com.rackspacecloud.blueflood.service.*;
 import com.rackspacecloud.blueflood.types.*;
 import com.rackspacecloud.blueflood.utils.TimeValue;
 import com.rackspacecloud.blueflood.utils.Util;
@@ -72,10 +70,17 @@ public class AstyanaxWriter extends AstyanaxIO {
 
 
     private boolean shouldPersistStringMetric(Metric metric) {
-        String currentValue = String.valueOf(metric.getMetricValue());
-        final String lastValue = AstyanaxReader.getInstance().getLastStringValue(metric.getLocator());
+        final boolean areStringMetricsDropped = Configuration.getInstance().getBooleanProperty(CoreConfig.STRING_METRICS_DROPPED);
 
-        return lastValue == null || !currentValue.equals(lastValue);
+        if(areStringMetricsDropped) {
+            return false;
+        }
+        else {
+            String currentValue = String.valueOf(metric.getMetricValue());
+            final String lastValue = AstyanaxReader.getInstance().getLastStringValue(metric.getLocator());
+
+            return lastValue == null || !currentValue.equals(lastValue);
+        }
     }
 
     private boolean shouldPersist(Metric metric) {

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -136,7 +136,8 @@ public enum CoreConfig implements ConfigDefaults {
     
     // how long we typically wait to schedule a rollup.
     ROLLUP_DELAY_MILLIS("300000"),
-    STRING_METRICS_DROPPED("false");
+    STRING_METRICS_DROPPED("false"),
+    TENANTIDS_TO_KEEP("");
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());

--- a/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
+++ b/blueflood-core/src/main/java/com/rackspacecloud/blueflood/service/CoreConfig.java
@@ -135,7 +135,8 @@ public enum CoreConfig implements ConfigDefaults {
     META_CACHE_RETENTION_IN_MINUTES("10"),
     
     // how long we typically wait to schedule a rollup.
-    ROLLUP_DELAY_MILLIS("300000");
+    ROLLUP_DELAY_MILLIS("300000"),
+    STRING_METRICS_DROPPED("false");
 
     static {
         Configuration.getInstance().loadDefaults(CoreConfig.values());


### PR DESCRIPTION
Based on https://github.com/rackerlabs/blueflood/pull/394

Drop String Metrics if so configured
 Also, added support to keep string metrics for certain tenants
Added tests to test this situation, where string metrics are configured to be dropped, but tenant id is excluded
